### PR TITLE
Implement access levels for courses(public/private)

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -52,7 +52,7 @@ class CoursesController < ApplicationController
     end
 
     def course_params
-        params.require(:course).permit(:title, :description, :instructor_id)
+        params.require(:course).permit(:title, :description, :instructor_id, :public)
     end
 
     def check_instructor

--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -4,6 +4,10 @@ class EnrollmentsController < ApplicationController
 
   def create
     if current_user.student?
+      if !@course.public
+        redirect_to @course, alert: "You can only enroll in public courses. Please ask the instructor for an invitation."
+        return
+      end
       enrollment = Enrollment.find_or_initialize_by(user: current_user, course: @course)
       if enrollment.persisted?
         redirect_to @course, notice: "You are already enrolled in this course."

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,4 +8,5 @@ class Course < ApplicationRecord
   validates :title, valid_characters: true, presence: true, length: { minimum: 5, maximum: 50 }
   validates :description, valid_characters: true, presence: true, length: { minimum: 10, maximum: 300 }
   validates :instructor, presence: true
+  validates :public, inclusion: { in: [true, false] }
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,5 +8,5 @@ class Course < ApplicationRecord
   validates :title, valid_characters: true, presence: true, length: { minimum: 5, maximum: 50 }
   validates :description, valid_characters: true, presence: true, length: { minimum: 10, maximum: 300 }
   validates :instructor, presence: true
-  validates :public, inclusion: { in: [true, false] }
+  validates :public, inclusion: { in: [ true, false ] }
 end

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -12,6 +12,10 @@
     <div class="field">
         <%= form.hidden_field :instructor_id %>
     </div>
+    <div class="field">
+        <%= form.label :public, "Public course?" %>
+        <%= form.check_box :public %>
+    </div>
     <div class="actions">
         <%= form.submit %>
     </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,7 +12,11 @@
     <h2><%= course.title %></h2>
     <p><%= course.description %></p>
     <p class="instructor">Instructor: <%= course.instructor.first_name %></p>
-
+    <p>
+      <span class="badge <%= course.public ? 'badge-public' : 'badge-private' %>">
+        <%= course.public ? "Public" : "Private" %>
+      </span>
+    </p>
     <% if current_user&.student? && current_user.enrolled_in?(course) %>
       <span class="badge">Enrolled</span>
     <% end %>
@@ -20,7 +24,7 @@
     <div class="actions">
       <div class="primary-actions">
         <%= link_to "View", course_path(course), class: "btn btn-info" %>
-        <% if current_user&.student? && !current_user.enrolled_in?(course) %>
+        <% if current_user&.student? && !current_user.enrolled_in?(course) && course.public %>
           <%= button_to "Enroll", course_enrollments_path(course), method: :post, class: "btn btn-primary" %>
         <% end %>
         <% if current_user&.student? && current_user.enrolled_in?(course) %>
@@ -132,6 +136,17 @@
     border: 1px solid #c3e6cb;
     border-radius: 999px;
     line-height: 1;
+  }
+
+  .badge-public {
+    color: #198754;
+    background-color: #e6f4ea;
+    border: 1px solid #c3e6cb;
+  }
+  .badge-private {
+    color: #b02a37;
+    background-color: #f8d7da;
+    border: 1px solid #f5c2c7;
   }
 
 </style>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -13,7 +13,7 @@
     <p><%= course.description %></p>
     <p class="instructor">Instructor: <%= course.instructor.first_name %></p>
     <p>
-      <span class="badge <%= course.public ? 'badge-public' : 'badge-private' %>">
+      <span class="badge <%= course.public ? "badge-public" : "badge-private" %>">
         <%= course.public ? "Public" : "Private" %>
       </span>
     </p>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -12,6 +12,10 @@
     <div class="field">
         <%= form.hidden_field :instructor_id, value: current_user.id %>
     </div>
+    <div class="field">
+        <%= form.label :public, "Public course?" %>
+        <%= form.check_box :public %>
+    </div>
     <div class="actions">
         <%= form.submit %>
     </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -8,7 +8,7 @@
 <p>Description: <%= @course.description %></p>
 <p>Instructor: <%= @course.instructor.first_name %></p>
 <p>
-  <span class="badge <%= @course.public ? 'badge-public' : 'badge-private' %>">
+  <span class="badge <%= @course.public ? "badge-public" : "badge-private" %>">
     <%= @course.public ? "Public" : "Private" %>
   </span>
 </p>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -7,7 +7,11 @@
 
 <p>Description: <%= @course.description %></p>
 <p>Instructor: <%= @course.instructor.first_name %></p>
-
+<p>
+  <span class="badge <%= @course.public ? 'badge-public' : 'badge-private' %>">
+    <%= @course.public ? "Public" : "Private" %>
+  </span>
+</p>
 <% @course_modules.each do |course_module| %>
     <%= course_module.title %>
     <%= link_to "Edit", edit_course_course_module_path(course_module.course_id, course_module.id) %>

--- a/db/migrate/20240707_add_public_to_courses.rb
+++ b/db/migrate/20240707_add_public_to_courses.rb
@@ -1,0 +1,5 @@
+class AddPublicToCourses < ActiveRecord::Migration[8.0]
+  def change
+    add_column :courses, :public, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_07_180000) do
     t.bigint "instructor_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "public", default: true, null: false
     t.index ["instructor_id"], name: "index_courses_on_instructor_id"
   end
 


### PR DESCRIPTION
### This PR introduces logic to support public and private course access levels. 
It ensures students can only enroll in public courses directly, while private course enrollment requires an invitation from the teacher.

---

Implemented restrictions:
- Students cannot enroll in private courses on their own.
- Private course enrollment requires a teacher invitation.

Introduced badges on course views to visually indicate access level:
- "Public" or "Private" badge displayed next to the course title.

Access Control Logic
- Public courses: any authenticated student can self-enroll.
- Private courses: visible (optional), but enrollment is invitation-only.