### PR TITLE
Use dotenv for environment variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "interactor"
 
 gem "pundit"
 
+gem "dotenv-rails"
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
@@ -76,7 +78,6 @@ group :test do
   gem "capybara"
   gem "shoulda-matchers"
   gem "simplecov", require: false
-  gem "rails-controller-testing"
 end
 
 gem "devise", "~> 4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,9 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (5.0.1)
@@ -445,6 +448,7 @@ DEPENDENCIES
   database_cleaner-active_record
   debug
   devise (~> 4.9)
+  dotenv-rails
   factory_bot_rails
   faker
   importmap-rails

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,6 +22,8 @@ default: &default
 
 development:
   <<: *default
+  username: <%= ENV["DATABASE_USERNAME"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
   database: studidi_development
 
   # The specified database role being used to connect to PostgreSQL.
@@ -56,6 +58,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  username: <%= ENV["DATABASE_USERNAME"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
   database: studidi_test
 
 # As with config/credentials.yml, you never want to store sensitive information,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
     port:                 587,
     domain:               "gmail.com",
     user_name:            "your_email@gmail.com",
-    password:             "your_password",
+    password:             ENV["APP_PASSWORD"],
     authentication:       "plain",
     enable_starttls_auto: true
   }


### PR DESCRIPTION
# Add dotenv-rails for Environment Variable Management
### This PR introduces the dotenv-rails gem to manage environment variables through a .env file, improving configuration flexibility and security across environments.

### Changes
- Added dotenv-rails gem to the Gemfile

- Configured usage of ENV[...] in appropriate places (e.g., database config)

Why
Using dotenv allows sensitive or environment-specific configuration (like API keys, DB credentials, etc.) to be stored outside the codebase. This makes local development and environment setup easier and more secure.