### PR TITLE
Cleanup notifications logic

### DIFF
--- a/app/interactors/enrollments/save_enrollment.rb
+++ b/app/interactors/enrollments/save_enrollment.rb
@@ -21,7 +21,6 @@ module Enrollments
             message = "Student #{context.user.first_name} enrolled on your course: #{context.course.title}"
             url = Rails.application.routes.url_helpers.course_path(context.course)
             EnrollmentNotifier.with(
-                recipient: context.course.instructor,
                 message: message,
                 url: url
             ).deliver_later(context.course.instructor)

--- a/app/interactors/invitations/create_invitation.rb
+++ b/app/interactors/invitations/create_invitation.rb
@@ -17,7 +17,6 @@ module Invitations
                 InvitationNotifier.with(
                     message: message,
                     url: url,
-                    recipient: recipient
                 ).deliver_later(recipient)
 
                 context.success

--- a/app/interactors/lessons/create_lesson.rb
+++ b/app/interactors/lessons/create_lesson.rb
@@ -14,7 +14,6 @@ module Lessons
                     LessonNotifier.with(
                         message: message,
                         url: url,
-                        recipient: student,
                     ).deliver_later(student)
                 end
 

--- a/app/interactors/lessons/update_lesson.rb
+++ b/app/interactors/lessons/update_lesson.rb
@@ -14,7 +14,6 @@ module Lessons
                     LessonNotifier.with(
                         message: message,
                         url: url,
-                        recipient: student,
                     ).deliver_later(student)
                 end
 

--- a/app/interactors/marks/create_mark.rb
+++ b/app/interactors/marks/create_mark.rb
@@ -25,7 +25,6 @@ module Marks
                 MarkNotifier.with(
                     message: message,
                     url: url,
-                    recipient: response.user
                 ).deliver_later(response.user)
 
                 context.mark = mark

--- a/app/interactors/marks/update_mark.rb
+++ b/app/interactors/marks/update_mark.rb
@@ -24,7 +24,6 @@ module Marks
                 MarkNotifier.with(
                     message: message,
                     url: url,
-                    recipient: response.user
                 ).deliver_later(response.user)
 
                 context.mark = mark

--- a/app/interactors/responses/create_response.rb
+++ b/app/interactors/responses/create_response.rb
@@ -20,7 +20,6 @@ module Responses
                 ResponseNotifier.with(
                     message: message,
                     url: url,
-                    recipient: @response.lesson.topic.course.instructor
                 ).deliver_later(@response.lesson.topic.course.instructor)
 
                 context.response = @response

--- a/app/notifiers/enrollment_notifier.rb
+++ b/app/notifiers/enrollment_notifier.rb
@@ -3,25 +3,11 @@
 # EnrollmentNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class EnrollmentNotifier < ApplicationNotifier
-  recipients -> { params[:recipient] }
-
-  deliver_by :database
   deliver_by :action_cable,
           stream: -> { "notifications_#{recipient.id}" },
           message: -> { params[:message] },
           url: -> { params[:url] },
           id: -> { notification.id }
-
-  required_param :message
-  required_param :url
-
-  def message
-    params[:message]
-  end
-
-  def url
-    params[:url]
-  end
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/invitation_notifier.rb
+++ b/app/notifiers/invitation_notifier.rb
@@ -3,25 +3,11 @@
 # InvitationNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class InvitationNotifier < ApplicationNotifier
-  recipients -> { params[:recipient] }
-
-  deliver_by :database
   deliver_by :action_cable,
           stream: -> { "notifications_#{recipient.id}" },
           message: -> { params[:message] },
           url: -> { params[:url] },
           id: -> { notification.id }
-
-  required_param :message
-  required_param :url
-
-  def message
-    params[:message]
-  end
-
-  def url
-    params[:url]
-  end
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/lesson_notifier.rb
+++ b/app/notifiers/lesson_notifier.rb
@@ -3,25 +3,11 @@
 # LessonNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class LessonNotifier < ApplicationNotifier
-  recipients -> { params[:recipient] }
-
-  deliver_by :database
   deliver_by :action_cable,
             stream: -> { "notifications_#{recipient.id}" },
             message: -> { params[:message] },
             url: -> { params[:url] },
             id: -> { notification.id }
-
-  required_param :message
-  required_param :url
-
-  def message
-    params[:message]
-  end
-
-  def url
-    params[:url]
-  end
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/mark_notifier.rb
+++ b/app/notifiers/mark_notifier.rb
@@ -3,25 +3,11 @@
 # MarkNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class MarkNotifier < ApplicationNotifier
-  recipients -> { params[:recipient] }
-
-  deliver_by :database
   deliver_by :action_cable,
             stream: -> { "notifications_#{recipient.id}" },
             message: -> { params[:message] },
             url: -> { params[:url] },
             id: -> { notification.id }
-
-  required_param :message
-  required_param :url
-
-  def message
-    params[:message]
-  end
-
-  def url
-    params[:url]
-  end
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/response_notifier.rb
+++ b/app/notifiers/response_notifier.rb
@@ -3,25 +3,11 @@
 # ResponseNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class ResponseNotifier < ApplicationNotifier
-  recipients -> { params[:recipient] }
-
-  deliver_by :database
   deliver_by :action_cable,
             stream: -> { "notifications_#{recipient.id}" },
             message: -> { params[:message] },
             url: -> { params[:url] },
             id: -> { notification.id }
-
-  required_param :message
-  required_param :url
-
-  def message
-    params[:message]
-  end
-
-  def url
-    params[:url]
-  end
   # Add your delivery methods
   #
   # deliver_by :email do |config|


### PR DESCRIPTION
### Summary

This PR includes several improvements to the notifiers to clean up redundant logic and align with defaults provided by the `noticed` gem (v2).

### Changes

-  Removed `deliver_by :database` since it's the default behavior in `noticed` v2.
-  Removed unnecessary `recipient` parameter when calling notifiers.
-  Cleaned up unused methods: `message`, `url`, and their associated `required_param` declarations.

### Reason

These changes reduce boilerplate, improve readability, and leverage defaults provided by the latest version of the `noticed` gem. The notifier logic is now more concise and maintainable.

### Impact

No functional changes to the notification delivery mechanism. Behavior remains consistent with previous implementation.
