### PR TITLE
Optimize notifiers and sql queries

### DIFF
--- a/app/interactors/lessons/update_lesson.rb
+++ b/app/interactors/lessons/update_lesson.rb
@@ -7,9 +7,9 @@ module Lessons
         def call
             update_lesson(context.id, context.params)
 
-            if @lesson.save
-                message = "Teacher #{@lesson.topic.course.instructor.first_name} posted a new lesson: #{@lesson.title}"
-                url = Rails.application.routes.url_helpers.lesson_path(@lesson)
+            if @lesson.persisted?
+                message = "Teacher #{@lesson.topic.course.instructor.first_name} updated lesson: #{@lesson.title}"
+                url = Rails.application.routes.url_helpers.course_topic_lesson_path(@lesson.topic.course, @lesson.topic, @lesson)
                 @lesson.topic.course.students.each do |student|
                     LessonNotifier.with(
                         message: message,

--- a/app/notifiers/application_notifier.rb
+++ b/app/notifiers/application_notifier.rb
@@ -1,2 +1,7 @@
 class ApplicationNotifier < Noticed::Event
+    deliver_by :action_cable,
+          stream: -> { "notifications_#{recipient.id}" },
+          message: -> { params[:message] },
+          url: -> { params[:url] },
+          id: -> { notification.id }
 end

--- a/app/notifiers/enrollment_notifier.rb
+++ b/app/notifiers/enrollment_notifier.rb
@@ -3,7 +3,6 @@
 # EnrollmentNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class EnrollmentNotifier < ApplicationNotifier
-  
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/enrollment_notifier.rb
+++ b/app/notifiers/enrollment_notifier.rb
@@ -3,11 +3,7 @@
 # EnrollmentNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class EnrollmentNotifier < ApplicationNotifier
-  deliver_by :action_cable,
-          stream: -> { "notifications_#{recipient.id}" },
-          message: -> { params[:message] },
-          url: -> { params[:url] },
-          id: -> { notification.id }
+  
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/invitation_notifier.rb
+++ b/app/notifiers/invitation_notifier.rb
@@ -3,7 +3,6 @@
 # InvitationNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class InvitationNotifier < ApplicationNotifier
-
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/invitation_notifier.rb
+++ b/app/notifiers/invitation_notifier.rb
@@ -3,11 +3,7 @@
 # InvitationNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class InvitationNotifier < ApplicationNotifier
-  deliver_by :action_cable,
-          stream: -> { "notifications_#{recipient.id}" },
-          message: -> { params[:message] },
-          url: -> { params[:url] },
-          id: -> { notification.id }
+
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/lesson_notifier.rb
+++ b/app/notifiers/lesson_notifier.rb
@@ -3,7 +3,6 @@
 # LessonNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class LessonNotifier < ApplicationNotifier
-
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/lesson_notifier.rb
+++ b/app/notifiers/lesson_notifier.rb
@@ -3,11 +3,7 @@
 # LessonNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class LessonNotifier < ApplicationNotifier
-  deliver_by :action_cable,
-            stream: -> { "notifications_#{recipient.id}" },
-            message: -> { params[:message] },
-            url: -> { params[:url] },
-            id: -> { notification.id }
+
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/mark_notifier.rb
+++ b/app/notifiers/mark_notifier.rb
@@ -3,11 +3,7 @@
 # MarkNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class MarkNotifier < ApplicationNotifier
-  deliver_by :action_cable,
-            stream: -> { "notifications_#{recipient.id}" },
-            message: -> { params[:message] },
-            url: -> { params[:url] },
-            id: -> { notification.id }
+
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/mark_notifier.rb
+++ b/app/notifiers/mark_notifier.rb
@@ -3,7 +3,6 @@
 # MarkNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class MarkNotifier < ApplicationNotifier
-
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/response_notifier.rb
+++ b/app/notifiers/response_notifier.rb
@@ -3,11 +3,7 @@
 # ResponseNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class ResponseNotifier < ApplicationNotifier
-  deliver_by :action_cable,
-            stream: -> { "notifications_#{recipient.id}" },
-            message: -> { params[:message] },
-            url: -> { params[:url] },
-            id: -> { notification.id }
+
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/notifiers/response_notifier.rb
+++ b/app/notifiers/response_notifier.rb
@@ -3,7 +3,6 @@
 # ResponseNotifier.with(record: @post, message: "New post").deliver(User.all)
 
 class ResponseNotifier < ApplicationNotifier
-
   # Add your delivery methods
   #
   # deliver_by :email do |config|

--- a/app/queries/student_report_query.rb
+++ b/app/queries/student_report_query.rb
@@ -1,0 +1,36 @@
+class StudentReportQuery
+  def initialize(student_id)
+    @student_id = student_id
+  end
+
+  def call
+    sql = <<-SQL
+      SELECT
+        c.id AS course_id,
+        c.title AS course_title,
+        c.ends_at AS course_ends_at,
+        COUNT(DISTINCT l.id) AS total_lessons,
+        COUNT(DISTINCT CASE WHEN r.id IS NOT NULL THEN l.id END) AS lessons_completed,
+        ROUND(AVG(m.value)::numeric, 2) AS average_mark,
+        CASE
+          WHEN COUNT(DISTINCT l.id) = 0 THEN 0
+          ELSE ROUND(
+            100.0 * COUNT(DISTINCT CASE WHEN r.id IS NOT NULL THEN l.id END) / COUNT(DISTINCT l.id),
+            2
+          )
+        END AS completion_percentage,
+        COUNT(m.id) AS marks_received
+      FROM courses c
+      INNER JOIN enrollments e ON e.course_id = c.id AND e.user_id = ?
+      LEFT JOIN topics t ON t.course_id = c.id
+      LEFT JOIN lessons l ON l.topic_id = t.id
+      LEFT JOIN responses r ON r.lesson_id = l.id AND r.user_id = ?
+      LEFT JOIN marks m ON m.response_id = r.id
+      GROUP BY c.id, c.title, c.ends_at
+      ORDER BY c.title;
+    SQL
+
+    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql, @student_id, @student_id])
+    ActiveRecord::Base.connection.execute(sanitized_sql)
+  end
+end

--- a/app/queries/student_report_query.rb
+++ b/app/queries/student_report_query.rb
@@ -30,7 +30,7 @@ class StudentReportQuery
       ORDER BY c.title;
     SQL
 
-    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql, @student_id, @student_id])
+    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [ sql, @student_id, @student_id ])
     ActiveRecord::Base.connection.execute(sanitized_sql)
   end
 end

--- a/app/queries/teacher_report_query.rb
+++ b/app/queries/teacher_report_query.rb
@@ -32,7 +32,7 @@ class TeacherReportQuery
       ORDER BY c.title;
     SQL
 
-    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql, @teacher_id])
+    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [ sql, @teacher_id ])
     ActiveRecord::Base.connection.execute(sanitized_sql)
   end
 end

--- a/app/queries/teacher_report_query.rb
+++ b/app/queries/teacher_report_query.rb
@@ -1,0 +1,38 @@
+# app/queries/teacher_report_query.rb
+class TeacherReportQuery
+  def initialize(teacher_id)
+    @teacher_id = teacher_id
+  end
+
+  def call
+    sql = <<-SQL
+      SELECT
+        c.id AS course_id,
+        c.title AS course_title,
+        COUNT(DISTINCT e.user_id) AS total_students,
+        COUNT(DISTINCT l.id) AS total_lessons,
+        ROUND(AVG(m.value)::numeric, 2) AS average_mark,
+        CASE
+          WHEN COUNT(DISTINCT l.id) = 0 OR COUNT(DISTINCT e.user_id) = 0 THEN 0
+          ELSE ROUND(
+            100.0 * COUNT(DISTINCT CONCAT(r.user_id, '-', r.lesson_id))
+            / (COUNT(DISTINCT l.id) * COUNT(DISTINCT e.user_id)),
+            2
+          )
+        END AS average_completion_percentage,
+        COUNT(DISTINCT r.id) AS total_responses
+      FROM courses c
+      LEFT JOIN enrollments e ON e.course_id = c.id
+      LEFT JOIN topics t ON t.course_id = c.id
+      LEFT JOIN lessons l ON l.topic_id = t.id
+      LEFT JOIN responses r ON r.lesson_id = l.id AND r.user_id = e.user_id
+      LEFT JOIN marks m ON m.response_id = r.id
+      WHERE c.instructor_id = ?
+      GROUP BY c.id, c.title
+      ORDER BY c.title;
+    SQL
+
+    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [sql, @teacher_id])
+    ActiveRecord::Base.connection.execute(sanitized_sql)
+  end
+end

--- a/app/services/student_report_service.rb
+++ b/app/services/student_report_service.rb
@@ -15,36 +15,9 @@ class StudentReportService
   end
 
   def reports
-    sql = <<-SQL
-      SELECT
-        c.id AS course_id,
-        c.title AS course_title,
-        c.ends_at AS course_ends_at,
-        COUNT(DISTINCT l.id) AS total_lessons,
-        COUNT(DISTINCT CASE WHEN r.id IS NOT NULL THEN l.id END) AS lessons_completed,
-        ROUND(AVG(m.value)::numeric, 2) AS average_mark,
-        CASE
-          WHEN COUNT(DISTINCT l.id) = 0 THEN 0
-          ELSE ROUND(
-            100.0 * COUNT(DISTINCT CASE WHEN r.id IS NOT NULL THEN l.id END) / COUNT(DISTINCT l.id),
-            2
-          )
-        END AS completion_percentage,
-        COUNT(m.id) AS marks_received
-      FROM courses c
-      INNER JOIN enrollments e ON e.course_id = c.id AND e.user_id = ?
-      LEFT JOIN topics t ON t.course_id = c.id
-      LEFT JOIN lessons l ON l.topic_id = t.id
-      LEFT JOIN responses r ON r.lesson_id = l.id AND r.user_id = ?
-      LEFT JOIN marks m ON m.response_id = r.id
-      GROUP BY c.id, c.title, c.ends_at
-      ORDER BY c.title;
-    SQL
+    rows = StudentReportQuery.new(@student_id).call
 
-    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [ sql, @student_id, @student_id ])
-    results = ActiveRecord::Base.connection.execute(sanitized_sql)
-
-    results.map do |row|
+    rows.map do |row|
       Report.new(
         row["course_id"],
         row["course_title"],

--- a/app/services/teacher_report_service.rb
+++ b/app/services/teacher_report_service.rb
@@ -13,38 +13,9 @@ class TeacherReportService
     @teacher_id = teacher_id
   end
 
-  # Returns array of Report structs
   def reports
-    sql = <<-SQL
-      SELECT
-        c.id AS course_id,
-        c.title AS course_title,
-        COUNT(DISTINCT e.user_id) AS total_students,
-        COUNT(DISTINCT l.id) AS total_lessons,
-        ROUND(AVG(m.value)::numeric, 2) AS average_mark,
-        CASE#{' '}
-          WHEN COUNT(DISTINCT l.id) = 0 OR COUNT(DISTINCT e.user_id) = 0 THEN 0
-          ELSE ROUND(
-            100.0 * COUNT(DISTINCT CONCAT(r.user_id, '-', r.lesson_id))#{' '}
-            / (COUNT(DISTINCT l.id) * COUNT(DISTINCT e.user_id)),
-            2
-          )
-        END AS average_completion_percentage,
-        COUNT(DISTINCT r.id) AS total_responses
-      FROM courses c
-      LEFT JOIN enrollments e ON e.course_id = c.id
-      LEFT JOIN topics t ON t.course_id = c.id
-      LEFT JOIN lessons l ON l.topic_id = t.id
-      LEFT JOIN responses r ON r.lesson_id = l.id AND r.user_id = e.user_id
-      LEFT JOIN marks m ON m.response_id = r.id
-      WHERE c.instructor_id = ?
-      GROUP BY c.id, c.title
-      ORDER BY c.title;
-    SQL
-
-    sanitized_sql = ActiveRecord::Base.send(:sanitize_sql_array, [ sql, @teacher_id ])
-    results = ActiveRecord::Base.connection.execute(sanitized_sql)
-    results.map do |row|
+    rows = TeacherReportQuery.new(@teacher_id).call
+    rows.map do |row|
       Report.new(
         row["course_id"],
         row["course_title"],


### PR DESCRIPTION
## Refactor: Move Student Report SQL to Query Object and move action cable configuration to Application Notifier

### Changes
- Extracted raw SQL from `StudentReportService` into a dedicated query class `StudentReportQuery`.
- Applied the same pattern as previously done for `TeacherReportService` to improve separation of concerns and readability.

### Enhancements
- Fixed incorrect usage of `course_topic_lesson_path` by passing the correct arguments.
- Added `@lesson.persisted?` check before attempting to send notifications.
  - Prevents unnecessary notification attempts when update fails.
- Moved `deliver_by :action_cable` configuration from individual notifiers to `ApplicationNotifier` to eliminate duplication and ensure consistency.

### Affected Components
- `StudentReportService`
- `StudentReportQuery`
- `Lessons::UpdateLesson` interactor
- `ApplicationNotifier` (Noticed config)

### Rationale
- Moving SQL to a dedicated query class keeps service objects focused on orchestration and simplifies testing.
- Centralizing Action Cable config avoids duplication across multiple notifiers.
- Persistence check ensures notification logic only runs on successful updates.

