### PR TITLE
Add quiz and quiz marks to sql queries for reports

### DIFF
--- a/app/queries/base_report_query.rb
+++ b/app/queries/base_report_query.rb
@@ -6,16 +6,23 @@ class BaseReportQuery
       c.ends_at AS course_ends_at,
       e.user_id AS student_id,
       l.id AS lesson_id,
-      r.id AS response_id,
-      r.user_id AS responder_id,
+      q.id AS question_id,
+      r.id AS lesson_response_id,
+      r.user_id AS lesson_responder_id,
+      qr.id AS question_response_id,
+      qr.user_id AS question_responder_id,
       m.value AS mark_value,
+      qm.value AS quiz_mark_value,
       c.instructor_id AS teacher_id
     FROM courses c
     LEFT JOIN enrollments e ON e.course_id = c.id
     LEFT JOIN topics t ON t.course_id = c.id
     LEFT JOIN lessons l ON l.topic_id = t.id
-    LEFT JOIN responses r ON r.lesson_id = l.id AND r.user_id = e.user_id
-    LEFT JOIN marks m ON m.response_id = r.id
+    LEFT JOIN questions q ON q.lesson_id = l.id
+    LEFT JOIN responses r ON r.responseable_type = 'Lesson' AND r.responseable_id = l.id AND r.user_id = e.user_id
+    LEFT JOIN responses qr ON qr.responseable_type = 'Question' AND qr.responseable_id = q.id AND qr.user_id = e.user_id
+    LEFT JOIN marks m ON (m.response_id = r.id OR m.response_id = qr.id)
+    LEFT JOIN marks qm ON qm.lesson_id = l.id AND qm.user_id = e.user_id AND qm.response_id IS NULL
   SQL
 
   def initialize(id)

--- a/app/queries/student_report_query.rb
+++ b/app/queries/student_report_query.rb
@@ -11,7 +11,7 @@ class StudentReportQuery < BaseReportQuery
         CASE
           WHEN COUNT(DISTINCT lesson_id) = 0 THEN 0
           ELSE ROUND(
-            100.0 * COUNT(DISTINCT CASE WHEN lesson_response_id IS NOT NULL OR question_response_id IS NOT NULL THEN lesson_id END) / 
+            100.0 * COUNT(DISTINCT CASE WHEN lesson_response_id IS NOT NULL OR question_response_id IS NOT NULL THEN lesson_id END) /#{' '}
                     COUNT(DISTINCT lesson_id),
             2
           )

--- a/app/queries/student_report_query.rb
+++ b/app/queries/student_report_query.rb
@@ -6,26 +6,17 @@ class StudentReportQuery < BaseReportQuery
         course_title,
         course_ends_at,
         COUNT(DISTINCT lesson_id) AS total_lessons,
-        COUNT(DISTINCT CASE WHEN response_id IS NOT NULL THEN lesson_id END) AS lessons_completed,
-        ROUND(AVG(mark_value)::numeric, 2) AS average_mark,
+        COUNT(DISTINCT CASE WHEN lesson_response_id IS NOT NULL OR question_response_id IS NOT NULL THEN lesson_id END) AS lessons_completed,
+        ROUND(AVG(COALESCE(mark_value, quiz_mark_value))::numeric, 2) AS average_mark,
         CASE
           WHEN COUNT(DISTINCT lesson_id) = 0 THEN 0
           ELSE ROUND(
-            100.0 * COUNT(DISTINCT CASE WHEN r.id IS NOT NULL OR qr.id IS NOT NULL THEN l.id END) /#{' '}
-                    COUNT(DISTINCT l.id),
+            100.0 * COUNT(DISTINCT CASE WHEN lesson_response_id IS NOT NULL OR question_response_id IS NOT NULL THEN lesson_id END) / 
+                    COUNT(DISTINCT lesson_id),
             2
           )
         END AS completion_percentage,
-        COUNT(m.id) AS marks_received
-      FROM courses c
-      INNER JOIN enrollments e ON e.course_id = c.id AND e.user_id = ?
-      LEFT JOIN topics t ON t.course_id = c.id
-      LEFT JOIN lessons l ON l.topic_id = t.id
-      LEFT JOIN questions q ON q.lesson_id = l.id
-      LEFT JOIN responses r ON r.responseable_type = 'Lesson' AND r.responseable_id = l.id AND r.user_id = ?
-      LEFT JOIN responses qr ON qr.responseable_type = 'Question' AND qr.responseable_id = q.id AND qr.user_id = ?
-      LEFT JOIN marks m ON (m.response_id = r.id OR m.response_id = qr.id)
-
+        COUNT(mark_value) + COUNT(quiz_mark_value) AS marks_received
       FROM #{BaseReportQuery.base_subquery}
       WHERE student_id = ?
       GROUP BY course_id, course_title, course_ends_at

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,7 @@
       </div>
     <% end %>
 
-    <div class="d-flex align-items-center position-relative">
+    <div class="d-flex align-items-start position-relative" style="padding-top: 12px;">
       <a href="/notifications" class="btn btn-link position-relative">
         <i class="bi bi-envelope-fill"></i>
         <span id="notification-badge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger d-none">•</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,8 +57,6 @@
       </a>
     </div>
 
-    
-
     <%= yield %>
   </body>
 </html>

--- a/spec/queries/student_report_query_spec.rb
+++ b/spec/queries/student_report_query_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe StudentReportQuery, type: :query do
       let!(:response2) { create(:response, user: student, lesson: lessons[1]) }
       let!(:mark1) { create(:mark, response: response1, value: 80) }
       let!(:mark2) { create(:mark, response: response2, value: 90) }
+      let!(:quiz_mark) { create(:mark, lesson: lessons[2], user: student, value: 70) }
 
       it 'returns the correct report data' do
         report = StudentReportQuery.new(student.id).call
@@ -23,9 +24,9 @@ RSpec.describe StudentReportQuery, type: :query do
         expect(result['course_title']).to eq(course.title)
         expect(result['total_lessons']).to eq(3)
         expect(result['lessons_completed']).to eq(2)
-        expect(result['average_mark'].to_f).to eq(85.0)
+        expect(result['average_mark'].to_f).to eq(80.0)
         expect(result['completion_percentage'].to_f).to eq(66.67)
-        expect(result['marks_received']).to eq(2)
+        expect(result['marks_received']).to eq(3)
       end
     end
 

--- a/spec/queries/teacher_report_query_spec.rb
+++ b/spec/queries/teacher_report_query_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe TeacherReportQuery, type: :query do
       let!(:response3) { create(:response, user: students[1], lesson: lessons[0]) }
       let!(:mark1) { create(:mark, response: response1, value: 80) }
       let!(:mark2) { create(:mark, response: response3, value: 90) }
+      let!(:quiz_mark) { create(:mark, lesson: lessons[2], user: students[0], value: 75) }
 
       it 'returns the correct report data for the teacher' do
         report = TeacherReportQuery.new(teacher.id).call
@@ -26,7 +27,7 @@ RSpec.describe TeacherReportQuery, type: :query do
         expect(result['course_id']).to eq(course.id)
         expect(result['total_students']).to eq(2)
         expect(result['total_lessons']).to eq(3)
-        expect(result['average_mark'].to_f).to eq(85.0)
+        expect(result['average_mark'].to_f).to eq(81.67)
         expect(result['average_completion_percentage'].to_f).to eq(50)
         expect(result['total_responses']).to eq(3)
       end


### PR DESCRIPTION
## Add Quiz Data to Reports and Improve Notification Badge Visibility

### Summary

This PR extends the reporting functionality by incorporating quiz data into the SQL queries for both students and teachers. It ensures quiz marks are counted toward the average and lesson completion statistics. Additionally, the notification envelope icon was slightly repositioned to make the notification badge fully visible in the UI.

### Changes

- **Enhanced SQL queries** in `BaseReportQuery`, `StudentReportQuery`, and `TeacherReportQuery`:
  - Included `questions` and `responses` for quiz submissions.
  - Added support for quiz marks via `quiz_mark_value`.
  - Used `COALESCE(mark_value, quiz_mark_value)` to accurately calculate `average_mark`.
  - Updated logic for counting completed lessons to include answered quiz questions.
- **Moved notification envelope** slightly lower in the layout to fully expose the notification badge when present.

### Impact

- Reports now reflect **both lesson and quiz performance**, giving a more comprehensive view of progress and engagement.
- UI improvement ensures **notification badge is no longer visually clipped**, improving UX clarity.

### Notes

- No changes made to business logic outside of SQL queries and CSS/UI alignment.
- This change prepares the ground for better performance tracking and encourages quiz participation.
